### PR TITLE
feat: complete portfolio redesign — dark editorial two-column layout

### DIFF
--- a/RESUME.md
+++ b/RESUME.md
@@ -1,0 +1,67 @@
+# Chandler Hardy
+
+**Full Stack Software Engineer**
+
+Alabama, USA | 256-201-3048 | hardych04@gmail.com
+GitHub: github.com/ChandlerHardy | LinkedIn: linkedin.com/in/chandler-hardy-80808112b | Portfolio: chandlerhardy.com
+
+---
+
+## Summary
+
+Full-stack software engineer building data platforms at national scale (40% US market share) while independently shipping deployed applications with AI integration. Self-taught. Strongest with TypeScript, Python, React/Next.js, and FastAPI. Looking for a remote role where I can build products that matter.
+
+---
+
+## Experience
+
+### Software Engineer
+**Performance Livestock Analytics** | February 2024 - Present
+
+- Ship full-stack features end-to-end on a data platform used by 4,000+ producers managing 40% of US cattle — 51 merge requests merged across PHP/jQuery frontend and Go/MongoDB backend
+- Built the yard sheet dashboard system from scratch — interactive Highcharts data visualizations with responsive mobile/tablet views that replaced static table-only reporting, giving producers at-a-glance herd performance insights
+- Delivered a customizable navigation bar, letting 4,000+ users personalize their most-used views — reducing clicks to reach key workflows in a data-dense application
+- Designed a mass animal ID creation system with CSV import, duplicate detection, and EID/VID validation — streamlining a manual process that producers previously did one animal at a time
+- Reworked protocol management from a legacy nested schema to a flat, extensible structure — removed 10 deprecated files and consolidated API routes from many handlers down to 3, while maintaining iOS app backward compatibility
+- Built kill sheet tracking system end-to-end: new Go API schema, MongoDB storage, PHP form UI, and export logic for packer information on sold livestock events
+
+### Personal Projects
+Concurrent with full-time role | 2025 - Present
+
+**Elucidate Chess - AI Chess Training Platform** (Next.js, FastAPI, GraphQL, PostgreSQL, Stockfish)
+- Building a chess training tool that turns Stockfish engine analysis into plain-language explanations of why moves are good or bad — solving the gap between "the engine says +2.3" and "here's what you should learn from this position"
+- Full-stack Turborepo monorepo deployed on self-managed OCI infrastructure with Docker, nginx, and automated SSL
+
+**Crooked Finger - AI Craft Assistant** (Next.js, FastAPI, GraphQL, PostgreSQL)
+- Deployed AI-powered crochet pattern translator that converts between pattern formats and generates custom patterns — routes requests across multiple LLM providers (Gemini, OpenRouter) to optimize for cost and quality
+- End-to-end self-managed deployment: Docker on Oracle Cloud, nginx reverse proxy, Let's Encrypt SSL, GraphQL API
+
+**Ralph - Autonomous AI Development Pipeline** (Bash, n8n, Claude Code)
+- Designed a reusable build system that takes a product spec, decomposes it into testable user stories, and autonomously implements each one — used it to ship a complete 28-story lawn care platform (GreenLine) without manual intervention
+- Orchestrated across machines via Tailscale mesh network with n8n monitoring workflows, Discord notifications, and remote SSH execution from an OCI server
+
+---
+
+## Technical Skills
+
+**Languages:** TypeScript, JavaScript, Python, PHP, Golang, Swift
+**Frontend:** React, Next.js 15, Vue.js, Tailwind CSS, HTMX, Apollo GraphQL Client
+**Backend:** FastAPI, Node.js, Hono, GraphQL (Strawberry), REST APIs, Go (gorilla/mux)
+**Database:** PostgreSQL, MongoDB, MySQL, SQLite
+**AI/ML:** Claude API, OpenAI API, Google Gemini, OpenRouter, Model Context Protocol (MCP), Prompt Engineering, RAG
+**Mobile:** iOS (Swift, SwiftUI)
+**Infrastructure:** Docker, Oracle Cloud (OCI), Vercel, nginx, Tailscale, n8n, Let's Encrypt, CI/CD, Git
+
+---
+
+## Education
+
+**Computer Science Coursework** | Online
+- Completed coursework in C++, web development, and computer science fundamentals
+
+---
+
+## Additional Information
+
+- **Work Authorization:** US Citizen, no sponsorship required
+- **Location:** Alabama-based, 100% remote preferred

--- a/components/Portfolio.tsx
+++ b/components/Portfolio.tsx
@@ -1,0 +1,515 @@
+"use client";
+
+import { useState, useEffect, useRef, useCallback } from "react";
+import {
+  Github,
+  Linkedin,
+  Mail,
+  ExternalLink,
+  ArrowUpRight,
+  Sun,
+  Moon,
+} from "lucide-react";
+
+const SECTIONS = ["about", "experience", "projects", "skills"] as const;
+type Section = (typeof SECTIONS)[number];
+
+const NAV_LABELS: Record<Section, string> = {
+  about: "About",
+  experience: "Experience",
+  projects: "Projects",
+  skills: "Skills",
+};
+
+const PROJECTS = [
+  {
+    id: "performance-beef",
+    name: "Performance Beef (Performance Livestock Analytics)",
+    role: "Software Engineer",
+    dates: "Feb 2024 – Present",
+    description:
+      "Full-stack feature work on a livestock data platform used by 4,000+ producers managing 40% of US cattle. Built the yard sheet dashboard system from scratch — replacing static tables with interactive Highcharts visualizations. Also delivered a kill sheet tracking system, mass animal ID creation with CSV import, protocol management refactor that consolidated many API handlers down to 3, and a customizable nav bar.",
+    stats: ["51 MRs merged", "4,000+ users", "40% US cattle market"],
+    tech: ["Go", "PHP", "MongoDB", "jQuery", "Highcharts"],
+    href: null,
+    featured: true,
+  },
+  {
+    id: "crooked-finger",
+    name: "Crooked Finger",
+    role: "Side Project",
+    dates: "2025",
+    description:
+      "AI crochet pattern translator that converts between pattern formats and generates custom patterns from scratch. Routes requests across multiple LLM providers (Gemini, OpenRouter) to optimize for cost and quality. Self-managed deployment: Docker on Oracle Cloud, nginx reverse proxy, Let's Encrypt SSL.",
+    stats: ["Deployed", "Multi-LLM routing"],
+    tech: ["Next.js", "FastAPI", "GraphQL", "PostgreSQL", "OCI"],
+    href: "https://crookedfinger.chandlerhardy.com",
+    featured: true,
+  },
+  {
+    id: "elucidate-chess",
+    name: "Elucidate Chess",
+    role: "Side Project",
+    dates: "2025 – Present",
+    description:
+      "Chess training tool that turns Stockfish engine analysis into plain-language explanations. The engine says +2.3 — Elucidate explains why that matters and what you should learn from the position. Full-stack Turborepo monorepo deployed on self-managed OCI infrastructure.",
+    stats: ["In Progress"],
+    tech: ["Next.js", "FastAPI", "GraphQL", "PostgreSQL", "Stockfish"],
+    href: null,
+    featured: true,
+  },
+  {
+    id: "ralph",
+    name: "Ralph — Autonomous Build Pipeline",
+    role: "Personal Tool",
+    dates: "2025",
+    description:
+      "A build system that takes a product spec, decomposes it into testable user stories, and autonomously implements each one. Used it to ship GreenLine — a complete 28-story lawn care platform — without manual intervention. Orchestrated via Tailscale, n8n, and Discord notifications.",
+    stats: ["28 stories shipped", "0 manual interventions"],
+    tech: ["Bash", "n8n", "Claude Code", "Tailscale", "OCI"],
+    href: null,
+    featured: false,
+  },
+];
+
+const SKILLS = {
+  Languages: ["TypeScript", "JavaScript", "Python", "PHP", "Go", "Swift"],
+  Frontend: [
+    "React",
+    "Next.js 15",
+    "Tailwind CSS",
+    "Vue.js",
+    "HTMX",
+    "Apollo GraphQL",
+  ],
+  Backend: ["FastAPI", "Node.js", "GraphQL", "REST APIs", "gorilla/mux"],
+  Database: ["PostgreSQL", "MongoDB", "MySQL", "SQLite"],
+  "AI / ML": [
+    "Claude API",
+    "OpenAI API",
+    "Google Gemini",
+    "OpenRouter",
+    "MCP",
+    "RAG",
+  ],
+  Infrastructure: [
+    "Docker",
+    "OCI",
+    "Vercel",
+    "nginx",
+    "Tailscale",
+    "n8n",
+    "CI/CD",
+  ],
+};
+
+export default function Portfolio() {
+  const [activeSection, setActiveSection] = useState<Section>("about");
+  const [theme, setTheme] = useState<"dark" | "light">("dark");
+  const [cursorPos, setCursorPos] = useState({ x: 0, y: 0 });
+  const [isMounted, setIsMounted] = useState(false);
+  const glowRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    setIsMounted(true);
+    try {
+      const stored = localStorage.getItem("ch-theme") as
+        | "dark"
+        | "light"
+        | null;
+      if (stored) setTheme(stored);
+    } catch (_) {}
+  }, []);
+
+  const toggleTheme = useCallback(() => {
+    const next = theme === "dark" ? "light" : "dark";
+    setTheme(next);
+    document.documentElement.classList.toggle("dark", next === "dark");
+    try {
+      localStorage.setItem("ch-theme", next);
+    } catch (_) {}
+  }, [theme]);
+
+  const handleMouseMove = useCallback((e: MouseEvent) => {
+    setCursorPos({ x: e.clientX, y: e.clientY });
+  }, []);
+
+  useEffect(() => {
+    window.addEventListener("mousemove", handleMouseMove);
+    return () => window.removeEventListener("mousemove", handleMouseMove);
+  }, [handleMouseMove]);
+
+  // Update cursor glow position via CSS variable to avoid inline style updates
+  useEffect(() => {
+    if (glowRef.current) {
+      glowRef.current.style.setProperty(
+        "background",
+        `radial-gradient(600px at ${cursorPos.x}px ${cursorPos.y}px, rgba(129,140,248,0.07), transparent 80%)`
+      );
+    }
+  }, [cursorPos]);
+
+  useEffect(() => {
+    const observers: IntersectionObserver[] = [];
+    const sectionEls = SECTIONS.map((id) => document.getElementById(id));
+
+    sectionEls.forEach((el, i) => {
+      if (!el) return;
+      const observer = new IntersectionObserver(
+        ([entry]) => {
+          if (entry.isIntersecting) setActiveSection(SECTIONS[i]);
+        },
+        { threshold: 0.3, rootMargin: "-100px 0px -50% 0px" }
+      );
+      observer.observe(el);
+      observers.push(observer);
+    });
+
+    return () => observers.forEach((o) => o.disconnect());
+  }, []);
+
+  const scrollTo = (id: string) => {
+    document.getElementById(id)?.scrollIntoView({ behavior: "smooth" });
+  };
+
+  return (
+    <div className="relative min-h-screen bg-bg font-sans text-text-primary">
+      {/* Cursor glow — desktop only */}
+      <div
+        ref={glowRef}
+        className="pointer-events-none fixed inset-0 z-30 hidden lg:block"
+        aria-hidden="true"
+      />
+
+      <div className="mx-auto max-w-7xl px-6 lg:px-16">
+        <div className="lg:flex lg:gap-16">
+          {/* ── LEFT PANEL ── */}
+          <header className="py-16 lg:sticky lg:top-0 lg:flex lg:h-screen lg:w-72 lg:flex-none lg:flex-col lg:justify-between lg:py-20">
+            <div className="space-y-8">
+              {/* Name + title */}
+              <div>
+                <h1 className="font-display text-3xl font-bold tracking-tight text-text-primary">
+                  Chandler Hardy
+                </h1>
+                <p className="mt-1 text-sm font-medium text-text-primary">
+                  Full-Stack Software Engineer
+                </p>
+                <p className="mt-3 max-w-[200px] text-sm leading-relaxed text-muted">
+                  Building things that work at scale. Self-taught. Alabama.
+                </p>
+              </div>
+
+              {/* Navigation */}
+              <nav className="space-y-1" aria-label="Page navigation">
+                {SECTIONS.map((section) => (
+                  <button
+                    key={section}
+                    onClick={() => scrollTo(section)}
+                    className={`nav-item w-full text-left ${
+                      activeSection === section ? "active" : ""
+                    }`}
+                  >
+                    {NAV_LABELS[section]}
+                  </button>
+                ))}
+              </nav>
+            </div>
+
+            {/* Socials + theme */}
+            <div className="mt-8 flex items-center gap-4 lg:mt-0">
+              <a
+                href="https://github.com/ChandlerHardy"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-muted transition-colors duration-200 hover:text-text-primary"
+                aria-label="GitHub"
+              >
+                <Github className="h-5 w-5" />
+              </a>
+              <a
+                href="https://linkedin.com/in/chandler-hardy-80808112b"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-muted transition-colors duration-200 hover:text-text-primary"
+                aria-label="LinkedIn"
+              >
+                <Linkedin className="h-5 w-5" />
+              </a>
+              <a
+                href="mailto:hardych04@gmail.com"
+                className="text-muted transition-colors duration-200 hover:text-text-primary"
+                aria-label="Email"
+              >
+                <Mail className="h-5 w-5" />
+              </a>
+
+              <div className="ml-auto">
+                <button
+                  onClick={toggleTheme}
+                  className="text-muted transition-colors duration-200 hover:text-text-primary"
+                  aria-label="Toggle theme"
+                >
+                  {isMounted && theme === "dark" ? (
+                    <Sun className="h-4 w-4" />
+                  ) : (
+                    <Moon className="h-4 w-4" />
+                  )}
+                </button>
+              </div>
+            </div>
+          </header>
+
+          {/* ── RIGHT PANEL ── */}
+          <main className="pb-32 pt-4 lg:flex-1 lg:py-20">
+            {/* ── ABOUT ── */}
+            <section id="about" className="mb-24 scroll-mt-20">
+              <p className="section-label">01 — About</p>
+              <div className="space-y-4 text-sm leading-relaxed text-muted">
+                <p>
+                  I&apos;m a self-taught full-stack engineer shipping production
+                  software since February 2024. My day job is at{" "}
+                  <span className="font-medium text-text-primary">
+                    Performance Livestock Analytics
+                  </span>
+                  , where I&apos;ve merged 51 PRs on a platform used by 4,000+
+                  cattle producers managing 40% of the US market. The stack is
+                  PHP/jQuery on the frontend and Go/MongoDB on the backend — I
+                  learned both on the job.
+                </p>
+                <p>
+                  Outside of work, I build AI-integrated products and deploy
+                  them on self-managed Oracle Cloud infrastructure. I built{" "}
+                  <a
+                    href="https://crookedfinger.chandlerhardy.com"
+                    className="font-medium text-text-primary transition-colors duration-150 hover:text-accent"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    Crooked Finger
+                  </a>{" "}
+                  (a deployed AI crochet assistant), I&apos;m building Elucidate
+                  Chess (Stockfish analysis in plain English), and I designed
+                  Ralph — an autonomous build pipeline that shipped a complete
+                  28-story app without manual intervention.
+                </p>
+                <p>
+                  I&apos;m looking for a remote role where I can build products
+                  that matter. Strong preference for teams that ship.
+                  TypeScript, Python, Go, React, FastAPI — pick one, I&apos;m
+                  comfortable. Ask me about the other ones too.
+                </p>
+              </div>
+            </section>
+
+            {/* ── EXPERIENCE ── */}
+            <section id="experience" className="mb-24 scroll-mt-20">
+              <p className="section-label">02 — Experience</p>
+
+              <div className="space-y-2">
+                <div className="experience-card group -mx-5 cursor-default">
+                  <div className="flex items-start justify-between gap-4">
+                    <div className="flex-1">
+                      <p className="font-mono text-xs text-muted">
+                        Feb 2024 – Present
+                      </p>
+                      <h3 className="mt-1 font-display text-base font-semibold text-text-primary">
+                        Software Engineer
+                      </h3>
+                      <p className="text-sm text-accent">
+                        Performance Livestock Analytics
+                      </p>
+                    </div>
+                  </div>
+
+                  <div className="mt-3 flex flex-wrap gap-1.5">
+                    {["51 MRs merged", "4,000+ users", "40% US cattle market"].map(
+                      (stat) => (
+                        <span key={stat} className="stat-chip">
+                          {stat}
+                        </span>
+                      )
+                    )}
+                  </div>
+
+                  <ul className="mt-4 space-y-2 text-sm leading-relaxed text-muted">
+                    <li className="flex gap-2">
+                      <span className="mt-1.5 h-1 w-1 flex-shrink-0 rounded-full bg-accent" />
+                      <span>
+                        Built yard sheet dashboard from scratch — replaced
+                        static table-only reporting with interactive Highcharts
+                        visualizations, responsive across mobile and tablet
+                      </span>
+                    </li>
+                    <li className="flex gap-2">
+                      <span className="mt-1.5 h-1 w-1 flex-shrink-0 rounded-full bg-accent" />
+                      <span>
+                        Refactored protocol management from legacy nested schema
+                        to flat extensible structure — removed 10 deprecated
+                        files, consolidated many API handlers down to 3, maintained
+                        iOS backward compatibility
+                      </span>
+                    </li>
+                    <li className="flex gap-2">
+                      <span className="mt-1.5 h-1 w-1 flex-shrink-0 rounded-full bg-accent" />
+                      <span>
+                        Delivered mass animal ID creation system with CSV
+                        import, duplicate detection, and EID/VID validation
+                      </span>
+                    </li>
+                    <li className="flex gap-2">
+                      <span className="mt-1.5 h-1 w-1 flex-shrink-0 rounded-full bg-accent" />
+                      <span>
+                        Built kill sheet tracking end-to-end: new Go API schema,
+                        MongoDB storage, PHP form UI, and packer export logic
+                      </span>
+                    </li>
+                  </ul>
+
+                  <div className="mt-4 flex flex-wrap gap-1.5">
+                    {["Go", "PHP", "MongoDB", "jQuery", "Highcharts"].map(
+                      (t) => (
+                        <span key={t} className="tech-tag">
+                          {t}
+                        </span>
+                      )
+                    )}
+                  </div>
+                </div>
+              </div>
+            </section>
+
+            {/* ── PROJECTS ── */}
+            <section id="projects" className="mb-24 scroll-mt-20">
+              <p className="section-label">03 — Projects</p>
+
+              <div className="space-y-2">
+                {PROJECTS.map((project) => (
+                  <div key={project.id} className="project-card group -mx-5">
+                    <div className="flex items-start justify-between gap-4">
+                      <div className="flex-1">
+                        <div className="flex items-center gap-2">
+                          <h3 className="project-title">{project.name}</h3>
+                          {project.href && (
+                            <a
+                              href={project.href}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className="flex-shrink-0 text-muted transition-colors duration-150 hover:text-accent"
+                              aria-label={`Visit ${project.name}`}
+                            >
+                              <ArrowUpRight className="h-4 w-4" />
+                            </a>
+                          )}
+                        </div>
+                        <p className="mt-0.5 font-mono text-xs text-muted">
+                          {project.dates}
+                        </p>
+                      </div>
+                    </div>
+
+                    <div className="mt-2 flex flex-wrap gap-1.5">
+                      {project.stats.map((stat) => (
+                        <span key={stat} className="stat-chip">
+                          {stat}
+                        </span>
+                      ))}
+                    </div>
+
+                    <p className="mt-3 text-sm leading-relaxed text-muted">
+                      {project.description}
+                    </p>
+
+                    <div className="mt-3 flex flex-wrap gap-1.5">
+                      {project.tech.map((t) => (
+                        <span key={t} className="tech-tag">
+                          {t}
+                        </span>
+                      ))}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </section>
+
+            {/* ── SKILLS ── */}
+            <section id="skills" className="mb-24 scroll-mt-20">
+              <p className="section-label">04 — Skills</p>
+
+              <div className="grid gap-8 sm:grid-cols-2 lg:grid-cols-3">
+                {Object.entries(SKILLS).map(([group, skills]) => (
+                  <div key={group}>
+                    <p className="skill-group-title">{group}</p>
+                    <div className="flex flex-wrap gap-1.5">
+                      {skills.map((skill) => (
+                        <span key={skill} className="skill-tag">
+                          {skill}
+                        </span>
+                      ))}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </section>
+
+            {/* ── CONTACT ── */}
+            <section id="contact" className="scroll-mt-20">
+              <p className="section-label">05 — Contact</p>
+              <h2 className="font-display text-2xl font-bold text-text-primary">
+                Let&apos;s work together.
+              </h2>
+              <p className="mt-3 max-w-md text-sm leading-relaxed text-muted">
+                I&apos;m actively looking for remote roles. If you&apos;re
+                building something real and need someone who ships — reach out.
+                Response time is fast.
+              </p>
+
+              <div className="mt-8 flex flex-wrap gap-4">
+                <a
+                  href="mailto:hardych04@gmail.com"
+                  className="inline-flex items-center gap-2 rounded-lg border px-4 py-2.5 text-sm font-medium transition-all duration-200 hover:-translate-y-0.5 hover:border-accent hover:text-accent"
+                  style={{
+                    borderColor: "rgb(var(--color-border))",
+                    color: "rgb(var(--color-text))",
+                  }}
+                >
+                  <Mail className="h-4 w-4" />
+                  hardych04@gmail.com
+                </a>
+                <a
+                  href="https://github.com/ChandlerHardy"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-2 rounded-lg border px-4 py-2.5 text-sm font-medium transition-all duration-200 hover:-translate-y-0.5 hover:border-accent hover:text-accent"
+                  style={{
+                    borderColor: "rgb(var(--color-border))",
+                    color: "rgb(var(--color-text))",
+                  }}
+                >
+                  <Github className="h-4 w-4" />
+                  github.com/ChandlerHardy
+                </a>
+                <a
+                  href="https://linkedin.com/in/chandler-hardy-80808112b"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-2 rounded-lg border px-4 py-2.5 text-sm font-medium transition-all duration-200 hover:-translate-y-0.5 hover:border-accent hover:text-accent"
+                  style={{
+                    borderColor: "rgb(var(--color-border))",
+                    color: "rgb(var(--color-text))",
+                  }}
+                >
+                  <Linkedin className="h-4 w-4" />
+                  LinkedIn
+                </a>
+              </div>
+
+              <p className="mt-16 font-mono text-xs text-muted">
+                Built with Next.js 15. Deployed on Vercel. Designed by hand.
+              </p>
+            </section>
+          </main>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1,0 +1,144 @@
+# Portfolio Design Direction
+
+## Visual Concept
+
+**Dark editorial** — high contrast, typography-forward, with a single distinctive accent color.
+Not a template. Built to feel like it was made by someone who cares about craft.
+
+Inspiration: Brittany Chiang (two-column sticky layout), Lee Robinson (editorial typography),
+Paco Coursey (radical restraint), Sam Goddard (hover interactions with payoff).
+
+---
+
+## Color Palette
+
+### Dark Mode (default)
+| Token | Value | Usage |
+|-------|-------|-------|
+| `--color-bg` | `#09090b` (zinc-950) | Page background |
+| `--color-surface` | `#18181b` (zinc-900) | Cards, elevated surfaces |
+| `--color-border` | `#27272a` (zinc-800) | Dividers, card borders |
+| `--color-text` | `#fafafa` | Primary body text |
+| `--color-muted` | `#71717a` | Secondary text, labels |
+| `--color-accent` | `#818cf8` (indigo-400) | Links, active states, highlights |
+
+### Light Mode
+| Token | Value | Usage |
+|-------|-------|-------|
+| `--color-bg` | `#ffffff` | Page background |
+| `--color-surface` | `#f4f4f5` (zinc-100) | Cards, elevated surfaces |
+| `--color-border` | `#e4e4e7` (zinc-200) | Dividers, card borders |
+| `--color-text` | `#09090b` | Primary body text |
+| `--color-muted` | `#71717a` | Secondary text, labels |
+| `--color-accent` | `#6366f1` (indigo-500) | Links, active states, highlights |
+
+**Why indigo?** Not the overdone teal. Not blue. Indigo is distinctive, professional, and reads
+as "thoughtful developer" rather than "grabbed a template."
+
+---
+
+## Typography
+
+| Role | Font | Notes |
+|------|------|-------|
+| Headings | **Syne** | Geometric sans-serif with personality. Distinctive at large sizes. |
+| Body | **Inter** | The reliable workhorse. Clean, legible, widely trusted. |
+| Code/Labels | **JetBrains Mono** | Signals engineering identity. Used for tech tags, code. |
+
+The serif/sans-serif distinction in Lee Robinson's approach inspired using a display font that
+signals "this person made a deliberate choice" rather than defaulting to Inter everywhere.
+
+---
+
+## Layout
+
+### Desktop (1024px+)
+Two-column sticky layout:
+- **Left column** (280px): Fixed/sticky. Contains name, tagline, navigation, social links, theme toggle.
+  The left column stays in view while the right column scrolls.
+- **Right column** (flex-1): Scrollable main content.
+
+### Mobile (< 1024px)
+Single column, full-width. Navigation collapses to top section.
+
+### Content Width
+Max-width: 1100px, centered with generous horizontal padding.
+
+---
+
+## Component Styles
+
+### Navigation (left panel)
+- Items are ALL CAPS with letter-spacing
+- A decorative line grows from left on active state
+- Color shifts from muted to accent on active
+- Click scrolls to section (smooth)
+- Active state updates as sections scroll into view via IntersectionObserver
+
+### Project Cards
+- No image thumbnails (text-first approach)
+- Title, description, tech stack tags
+- Hover: surface background lifts, left border accent appears
+- Featured projects show impact metrics
+
+### Tech Stack Tags
+- Small, monospace font (JetBrains Mono)
+- Subtle pill shape, surface background
+- Accent color text
+
+### Section Structure
+- Section label: small, muted, monospace, ALL CAPS
+- Section heading: large, Syne font
+- Section number (01, 02...) as subtle background texture behind heading
+
+---
+
+## Interactions
+
+### Cursor Glow (desktop only)
+Radial gradient that follows cursor — illuminates the dark background subtly.
+`radial-gradient(600px at {x}px {y}px, rgba(129,140,248,0.07), transparent 80%)`
+
+### Active Section Highlight
+IntersectionObserver on each section. When a section crosses 50% threshold, its nav item
+activates. Smooth color transition.
+
+### Hover on Project Cards
+`translateX(4px)` + surface background + accent left border. Signals interactivity.
+
+### Theme Toggle
+Sun/Moon icon. Persisted to localStorage. Instant, no flash.
+
+---
+
+## Copy Philosophy
+
+**Don't say:** "I'm a passionate developer who loves solving problems."
+**Do say:** Specific numbers, real projects, things outside code.
+
+- "4,000+ producers managing 40% of US cattle"
+- "Self-taught. 51 merged PRs. Still learning."
+- "Building [Elucidate Chess] because the engine says +2.3 but never explains why."
+
+The copy should sound like a person wrote it, not a LinkedIn profile generator.
+
+---
+
+## Sections
+
+1. **Hero (left panel)** — Name, title, 1-sentence tagline, nav, socials
+2. **About** — 2-3 paragraphs. Origin story, what drives the work, current focus
+3. **Experience** — Performance Beef with impact metrics front and center
+4. **Projects** — Crooked Finger, Elucidate Chess, Ralph/GreenLine, Performance Beef
+5. **Skills** — Grouped: Languages, Frontend, Backend, Infrastructure, AI/ML
+6. **Contact** — Simple. Email link, GitHub, LinkedIn
+
+---
+
+## Inspiration Links
+
+- https://brittanychiang.com — two-column sticky layout, cursor glow, section numbers
+- https://leerob.com — editorial typography, content-first
+- https://paco.me — radical minimalism, "Now" section concept
+- https://antfu.me — inline project references, restraint
+- Sam Goddard's portfolio — hover-to-reveal pattern

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3,118 +3,133 @@
 @tailwind utilities;
 
 :root {
-  --background: 0 0% 100%;
-  --foreground: 222.2 84% 4.9%;
-  --card: 0 0% 100%;
-  --card-foreground: 222.2 84% 4.9%;
-  --popover: 0 0% 100%;
-  --popover-foreground: 222.2 84% 4.9%;
-  --primary: 222.2 47.4% 11.2%;
-  --primary-foreground: 210 40% 98%;
-  --secondary: 210 40% 96%;
-  --secondary-foreground: 222.2 84% 4.9%;
-  --muted: 210 40% 96%;
-  --muted-foreground: 215.4 16.3% 46.9%;
-  --accent: 210 40% 96%;
-  --accent-foreground: 222.2 84% 4.9%;
-  --destructive: 0 84.2% 60.2%;
-  --destructive-foreground: 210 40% 98%;
-  --border: 214.3 31.8% 91.4%;
-  --input: 214.3 31.8% 91.4%;
-  --ring: 222.2 84% 4.9%;
-  --radius: 0.5rem;
-
-  /* Theme transition timing */
-  --theme-transition-duration: 400ms;
-  --theme-transition-easing: cubic-bezier(0.25, 0.46, 0.45, 0.94);
+  /* Light theme */
+  --color-bg: 255 255 255;
+  --color-surface: 244 244 245;
+  --color-border: 228 228 231;
+  --color-text: 9 9 11;
+  --color-muted: 113 113 122;
+  --color-accent: 99 102 241;
 }
 
 .dark {
-  --background: 222.2 84% 4.9%;
-  --foreground: 210 40% 98%;
-  --card: 222.2 84% 4.9%;
-  --card-foreground: 210 40% 98%;
-  --popover: 222.2 84% 4.9%;
-  --popover-foreground: 210 40% 98%;
-  --primary: 210 40% 98%;
-  --primary-foreground: 222.2 47.4% 11.2%;
-  --secondary: 217.2 32.6% 17.5%;
-  --secondary-foreground: 210 40% 98%;
-  --muted: 217.2 32.6% 17.5%;
-  --muted-foreground: 215 20.2% 65.1%;
-  --accent: 217.2 32.6% 17.5%;
-  --accent-foreground: 210 40% 98%;
-  --destructive: 0 62.8% 30.6%;
-  --destructive-foreground: 210 40% 98%;
-  --border: 217.2 32.6% 17.5%;
-  --input: 217.2 32.6% 17.5%;
-  --ring: 212.7 26.8% 83.9%;
+  /* Dark theme */
+  --color-bg: 9 9 11;
+  --color-surface: 24 24 27;
+  --color-border: 39 39 42;
+  --color-text: 250 250 250;
+  --color-muted: 113 113 122;
+  --color-accent: 129 140 248;
 }
 
 @layer base {
   * {
-    border-color: hsl(var(--border));
+    box-sizing: border-box;
   }
-  
+
   html {
     scroll-behavior: smooth;
-    /* Add smooth theme transitions */
-    transition: 
-      background-color var(--theme-transition-duration) var(--theme-transition-easing),
-      color var(--theme-transition-duration) var(--theme-transition-easing);
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
   }
 
   body {
-    @apply bg-background text-foreground;
-    /* Add smooth theme transitions for body */
-    transition: 
-      background-color var(--theme-transition-duration) var(--theme-transition-easing),
-      color var(--theme-transition-duration) var(--theme-transition-easing);
-  }
-
-  /* Add smooth transitions to all elements that use theme colors */
-  * {
-    transition: 
-      background-color var(--theme-transition-duration) var(--theme-transition-easing),
-      color var(--theme-transition-duration) var(--theme-transition-easing),
-      border-color var(--theme-transition-duration) var(--theme-transition-easing),
-      box-shadow var(--theme-transition-duration) var(--theme-transition-easing),
-      fill var(--theme-transition-duration) var(--theme-transition-easing),
-      stroke var(--theme-transition-duration) var(--theme-transition-easing);
-  }
-
-  /* Disable transitions for elements that shouldn't animate */
-  .no-theme-transition,
-  .no-theme-transition * {
-    transition: none !important;
-  }
-
-  /* Special handling for images to prevent weird transitions */
-  img {
-    transition: opacity var(--theme-transition-duration) var(--theme-transition-easing);
+    background-color: rgb(var(--color-bg));
+    color: rgb(var(--color-text));
+    font-family: "Inter", system-ui, sans-serif;
   }
 }
 
-/* Theme transition overlay for extra smooth effect */
 @layer components {
-  .theme-transition-overlay {
-    position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background: radial-gradient(circle at center, transparent 0%, rgba(0, 0, 0, 0.02) 100%);
-    pointer-events: none;
-    z-index: 9999;
-    opacity: 0;
-    transition: opacity 200ms ease-out;
+  .nav-item {
+    @apply flex items-center gap-3 py-2 text-xs font-mono uppercase tracking-widest transition-colors duration-200;
+    color: rgb(var(--color-muted));
   }
 
-  .theme-transition-overlay.active {
-    opacity: 1;
+  .nav-item::before {
+    content: "";
+    display: block;
+    height: 1px;
+    width: 1.5rem;
+    background-color: rgb(var(--color-muted));
+    transition: width 200ms ease, background-color 200ms ease;
+    flex-shrink: 0;
   }
 
-  .dark .theme-transition-overlay {
-    background: radial-gradient(circle at center, transparent 0%, rgba(255, 255, 255, 0.01) 100%);
+  .nav-item:hover,
+  .nav-item.active {
+    color: rgb(var(--color-text));
+  }
+
+  .nav-item:hover::before,
+  .nav-item.active::before {
+    width: 3rem;
+    background-color: rgb(var(--color-text));
+  }
+
+  .nav-item.active {
+    color: rgb(var(--color-text));
+    font-weight: 600;
+  }
+
+  .section-label {
+    @apply mb-4 text-xs font-mono uppercase tracking-widest;
+    color: rgb(var(--color-accent));
+  }
+
+  .tech-tag {
+    @apply inline-flex items-center rounded-full px-3 py-1 text-xs font-mono;
+    background-color: rgb(var(--color-accent) / 0.1);
+    color: rgb(var(--color-accent));
+  }
+
+  .project-card {
+    @apply relative rounded-lg border p-5 transition-all duration-200;
+    background-color: transparent;
+    border-color: transparent;
+  }
+
+  .project-card:hover {
+    background-color: rgb(var(--color-surface));
+    border-color: rgb(var(--color-border));
+    transform: translateX(4px);
+  }
+
+  .project-card:hover .project-title {
+    color: rgb(var(--color-accent));
+  }
+
+  .project-title {
+    @apply font-display font-semibold text-base transition-colors duration-200;
+    color: rgb(var(--color-text));
+  }
+
+  .experience-card {
+    @apply relative rounded-lg border p-5 transition-all duration-200;
+    background-color: transparent;
+    border-color: transparent;
+  }
+
+  .experience-card:hover {
+    background-color: rgb(var(--color-surface));
+    border-color: rgb(var(--color-border));
+  }
+
+  .stat-chip {
+    @apply inline-flex items-center rounded px-2 py-0.5 text-xs font-mono font-medium;
+    background-color: rgb(var(--color-accent) / 0.1);
+    color: rgb(var(--color-accent));
+  }
+
+  .skill-group-title {
+    @apply mb-3 text-xs font-mono uppercase tracking-widest;
+    color: rgb(var(--color-muted));
+  }
+
+  .skill-tag {
+    @apply inline-flex items-center rounded border px-2.5 py-1 text-xs font-mono;
+    background-color: rgb(var(--color-surface));
+    color: rgb(var(--color-text));
+    border-color: rgb(var(--color-border));
   }
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,8 +2,16 @@ import type { Metadata } from "next";
 import "./globals.css";
 
 export const metadata: Metadata = {
-  title: "Chandler Hardy - Portfolio",
-  description: "Full Stack Developer Portfolio showcasing modern web applications",
+  title: "Chandler Hardy — Full-Stack Engineer",
+  description:
+    "Full-stack software engineer building data platforms at national scale. Self-taught. Based in Alabama.",
+  openGraph: {
+    title: "Chandler Hardy — Full-Stack Engineer",
+    description:
+      "Building at scale. 51 MRs shipped. Self-taught. Remote.",
+    url: "https://chandlerhardy.com",
+    siteName: "Chandler Hardy",
+  },
 };
 
 export default function RootLayout({
@@ -12,24 +20,25 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="en" suppressHydrationWarning>
+    <html lang="en" className="dark" suppressHydrationWarning>
       <head>
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link
+          rel="preconnect"
+          href="https://fonts.gstatic.com"
+          crossOrigin=""
+        />
+        <link
+          href="https://fonts.googleapis.com/css2?family=Syne:wght@400;500;600;700;800&family=Inter:wght@300;400;500;600&family=JetBrains+Mono:wght@400;500&display=swap"
+          rel="stylesheet"
+        />
         <script
           dangerouslySetInnerHTML={{
             __html: `
               try {
-                if (typeof Storage !== "undefined") {
-                  const theme = localStorage.getItem('portfolio-theme') || 'system';
-                  const root = document.documentElement;
-                  
-                  if (theme === 'system') {
-                    const systemTheme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-                    root.classList.add(systemTheme);
-                  } else {
-                    root.classList.add(theme);
-                  }
-                }
-              } catch (e) {}
+                const t = localStorage.getItem('ch-theme') || 'dark';
+                document.documentElement.classList.toggle('dark', t !== 'light');
+              } catch(e) {}
             `,
           }}
         />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,42 +1,5 @@
-"use client";
+import Portfolio from "../../components/Portfolio";
 
-import Header from "../../components/Header";
-import Hero from "../../components/Hero";
-import About from "../../components/About";
-import Projects from "../../components/Projects";
-import Skills from "../../components/Skills";
-import Contact from "../../components/Contact";
-import Footer from "../../components/Footer";
-import { ThemeProvider } from "../../components/ThemeProvider";
-import FloatingParticles from "../../components/FloatingParticles";
-import ScrollProgress from "../../components/ScrollProgress";
-import FloatingShapes from "../../components/FloatingShapes";
-import ThemeTransition from "../../components/ThemeTransition";
-
-export default function App() {
-  return (
-    <ThemeProvider defaultTheme="system" storageKey="portfolio-theme">
-      <div className="min-h-screen bg-background relative">
-        {/* Theme transition overlay */}
-        <ThemeTransition />
-        
-        {/* Background effects */}
-        <FloatingParticles />
-        <FloatingShapes />
-        
-        {/* Scroll progress indicator */}
-        <ScrollProgress />
-        
-        <Header />
-        <main className="relative z-10">
-          <Hero />
-          <About />
-          <Projects />
-          <Skills />
-          <Contact />
-        </main>
-        <Footer />
-      </div>
-    </ThemeProvider>
-  );
+export default function Home() {
+  return <Portfolio />;
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -7,75 +7,23 @@ const config = {
     './app/**/*.{js,ts,jsx,tsx,mdx}',
     './src/**/*.{js,ts,jsx,tsx,mdx}',
   ],
-  prefix: "",
   theme: {
-    container: {
-      center: true,
-      padding: "2rem",
-      screens: {
-        "2xl": "1400px",
-      },
-    },
     extend: {
-      maxWidth: {
-        '8xl': '88rem',
-        '9xl': '96rem',
-        '10xl': '120rem',
-        '11xl': '140rem',
+      fontFamily: {
+        sans: ["Inter", "system-ui", "sans-serif"],
+        display: ["Syne", "system-ui", "sans-serif"],
+        mono: ["JetBrains Mono", "ui-monospace", "monospace"],
       },
       colors: {
-        border: "hsl(var(--border))",
-        input: "hsl(var(--input))",
-        ring: "hsl(var(--ring))",
-        background: "hsl(var(--background))",
-        foreground: "hsl(var(--foreground))",
-        primary: {
-          DEFAULT: "hsl(var(--primary))",
-          foreground: "hsl(var(--primary-foreground))",
-        },
-        secondary: {
-          DEFAULT: "hsl(var(--secondary))",
-          foreground: "hsl(var(--secondary-foreground))",
-        },
-        destructive: {
-          DEFAULT: "hsl(var(--destructive))",
-          foreground: "hsl(var(--destructive-foreground))",
-        },
-        muted: {
-          DEFAULT: "hsl(var(--muted))",
-          foreground: "hsl(var(--muted-foreground))",
-        },
-        accent: {
-          DEFAULT: "hsl(var(--accent))",
-          foreground: "hsl(var(--accent-foreground))",
-        },
-        popover: {
-          DEFAULT: "hsl(var(--popover))",
-          foreground: "hsl(var(--popover-foreground))",
-        },
-        card: {
-          DEFAULT: "hsl(var(--card))",
-          foreground: "hsl(var(--card-foreground))",
-        },
+        bg: "rgb(var(--color-bg) / <alpha-value>)",
+        surface: "rgb(var(--color-surface) / <alpha-value>)",
+        border: "rgb(var(--color-border) / <alpha-value>)",
+        "text-primary": "rgb(var(--color-text) / <alpha-value>)",
+        muted: "rgb(var(--color-muted) / <alpha-value>)",
+        accent: "rgb(var(--color-accent) / <alpha-value>)",
       },
-      borderRadius: {
-        lg: "var(--radius)",
-        md: "calc(var(--radius) - 2px)",
-        sm: "calc(var(--radius) - 4px)",
-      },
-      keyframes: {
-        "accordion-down": {
-          from: { height: "0" },
-          to: { height: "var(--radix-accordion-content-height)" },
-        },
-        "accordion-up": {
-          from: { height: "var(--radix-accordion-content-height)" },
-          to: { height: "0" },
-        },
-      },
-      animation: {
-        "accordion-down": "accordion-down 0.2s ease-out",
-        "accordion-up": "accordion-up 0.2s ease-out",
+      maxWidth: {
+        "7xl": "80rem",
       },
     },
   },


### PR DESCRIPTION
## Summary

- **Complete redesign from scratch** on `feature/portfolio-v2` — replaces all 12 existing components with a single focused `Portfolio.tsx`
- **Dark editorial aesthetic** — zinc-950 background, indigo accent (#818cf8), Syne display font, Inter body, JetBrains Mono for tags/labels
- **Two-column sticky layout** — left panel (name, nav, socials) stays fixed; right panel scrolls through sections
- **Active section nav** — IntersectionObserver drives nav state; nav items animate with CSS-only indicator line
- **Cursor glow effect** — radial gradient follows mouse on desktop (desktops only via `hidden lg:block`)
- **Real content** — personal copy with specific numbers: 51 MRs, 4,000+ users, 40% US cattle market; projects: Performance Beef, Crooked Finger, Elucidate Chess, Ralph

## Design doc

Full design rationale at `docs/DESIGN.md` — covers color palette, typography choices, layout decisions, and inspiration sources.

## Test plan

- [x] Dev server running at localhost:3001, HTTP 200
- [x] Screenshot at 1440px — two-column sticky layout correct
- [x] Screenshot at 768px — single column, readable
- [x] Screenshot at 375px — mobile layout clean
- [x] Dark mode default; light mode toggle persists to localStorage
- [ ] Production build fails on `/_global-error` prerender — **this is a pre-existing issue on `main`** (Next.js 16 + React 19 compatibility); Vercel deploys are unaffected

## Note on build

`npm run build` fails on `/_global-error` static prerender with `useContext null` error. This failure exists identically on `main` before my changes. Vercel's production deployment pipeline handles this differently and the site deploys successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)