### PR TITLE
heartbeat: Add robots.txt and sitemap generation

### DIFF
--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,11 @@
+import type { MetadataRoute } from "next";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: "*",
+      allow: "/",
+    },
+    sitemap: "https://chandlerhardy.com/sitemap.xml",
+  };
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,17 @@
+import type { MetadataRoute } from "next";
+import { projects } from "@/data/projects";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const projectUrls = projects.map((project) => ({
+    url: `https://chandlerhardy.com/projects/${project.slug}`,
+    lastModified: new Date(),
+  }));
+
+  return [
+    {
+      url: "https://chandlerhardy.com",
+      lastModified: new Date(),
+    },
+    ...projectUrls,
+  ];
+}


### PR DESCRIPTION
## Heartbeat Auto-Implementation

**What:** Create Next.js App Router robots.ts and sitemap.ts files to auto-generate robots.txt and sitemap.xml with project detail page URLs.
**Why:** No robots.txt or sitemap means search engines have no guidance crawling the site. Basic SEO table stakes for a portfolio that should be discoverable.
**Files:** src/app/robots.ts, src/app/sitemap.ts

---
*Automatically discovered and implemented by Heartbeat on 2026-04-03.*
*Review and merge at your convenience.*