### PR TITLE
Extract hardcoded project slugs in HomeWindow

### DIFF
--- a/components/windows/HomeWindow.tsx
+++ b/components/windows/HomeWindow.tsx
@@ -1,16 +1,14 @@
 "use client";
 
-import { projects } from "../../src/data/projects";
+import { getFeaturedProjects } from "../../src/data/projects";
 
 interface HomeWindowProps {
   onOpenProject: (slug: string) => void;
   onOpenWindow: (id: string) => void;
 }
 
-const FEATURED_SLUGS = ["chronicle", "crooked-finger", "elucidate-chess"];
-
 export default function HomeWindow({ onOpenProject, onOpenWindow }: HomeWindowProps) {
-  const featured = FEATURED_SLUGS.map((s) => projects.find((p) => p.slug === s)!);
+  const featured = getFeaturedProjects();
 
   return (
     <div style={{ fontFamily: "'Trebuchet MS', Tahoma, sans-serif", color: "#000" }}>

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -309,6 +309,13 @@ export const projects: Project[] = [
   }
 ];
 
+/** Number of projects shown on the home screen. */
+export const FEATURED_COUNT = 3;
+
+export function getFeaturedProjects(): Project[] {
+  return projects.slice(0, FEATURED_COUNT);
+}
+
 export function getProjectBySlug(slug: string): Project | undefined {
   return projects.find(p => p.slug === slug);
 }


### PR DESCRIPTION
## Summary
- Replaced the hardcoded `FEATURED_SLUGS` array in `HomeWindow.tsx` with a `getFeaturedProjects()` helper derived from the projects data source
- Added `FEATURED_COUNT` constant and `getFeaturedProjects()` to `src/data/projects.ts`
- Adding or reordering projects in `projects.ts` now automatically updates the home window featured list

Closes #21

## Test plan
- [ ] Verify home page still renders the first 3 projects correctly
- [ ] Reorder projects in `projects.ts` and confirm the home window updates accordingly
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)