### PR TITLE
heartbeat: GreenLine 'Source Code' link points to empty string

### DIFF
--- a/components/windows/ProjectDetailWindow.tsx
+++ b/components/windows/ProjectDetailWindow.tsx
@@ -96,23 +96,25 @@ export default function ProjectDetailWindow({ slug, onBack }: ProjectDetailWindo
             🌐 Live Site
           </a>
         )}
-        <a
-          href={project.githubUrl}
-          target="_blank"
-          rel="noopener noreferrer"
-          style={{
-            background: "#c0c0c0",
-            border: "2px solid",
-            borderColor: "#ffffff #808080 #808080 #ffffff",
-            padding: "4px 12px",
-            cursor: "pointer",
-            fontSize: 11,
-            textDecoration: "none",
-            color: "#000",
-          }}
-        >
-          📂 Source Code
-        </a>
+        {project.githubUrl && (
+          <a
+            href={project.githubUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            style={{
+              background: "#c0c0c0",
+              border: "2px solid",
+              borderColor: "#ffffff #808080 #808080 #ffffff",
+              padding: "4px 12px",
+              cursor: "pointer",
+              fontSize: 11,
+              textDecoration: "none",
+              color: "#000",
+            }}
+          >
+            📂 Source Code
+          </a>
+        )}
       </div>
 
       {/* Overview */}

--- a/src/app/projects/[slug]/project-detail-client.tsx
+++ b/src/app/projects/[slug]/project-detail-client.tsx
@@ -116,23 +116,25 @@ export default function ProjectDetailClient({ project }: { project: Project }) {
               🌐 Live Site
             </a>
           )}
-          <a
-            href={project.githubUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-            style={{
-              background: "#c0c0c0",
-              border: "2px solid",
-              borderColor: "#ffffff #808080 #808080 #ffffff",
-              padding: "2px 12px",
-              cursor: "pointer",
-              fontSize: 11,
-              textDecoration: "none",
-              color: "#000",
-            }}
-          >
-            📂 Source
-          </a>
+          {project.githubUrl && (
+            <a
+              href={project.githubUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              style={{
+                background: "#c0c0c0",
+                border: "2px solid",
+                borderColor: "#ffffff #808080 #808080 #ffffff",
+                padding: "2px 12px",
+                cursor: "pointer",
+                fontSize: 11,
+                textDecoration: "none",
+                color: "#000",
+              }}
+            >
+              📂 Source
+            </a>
+          )}
         </div>
 
         {/* Content */}


### PR DESCRIPTION
## Heartbeat Auto-Implementation

**What:** GreenLine's githubUrl is an empty string (''), but ProjectDetailWindow unconditionally renders a '📂 Source Code' link for every project. This creates a broken <a href=''> that navigates to the current page. Either hide the Source Code button when githubUrl is empty/falsy (like the liveUrl check already does), or set a valid URL.
**Why:** Clicking 'Source Code' on the GreenLine project detail reloads the page — confusing for a recruiter reviewing projects. The liveUrl already has a guard (project.liveUrl && project.liveUrl !== '#') but githubUrl doesn't.
**Files:** src/data/projects.ts, components/windows/ProjectDetailWindow.tsx

---
*Automatically discovered and implemented by Heartbeat on 2026-04-06.*
*Review and merge at your convenience.*

Closes #29